### PR TITLE
Hide title bar of presentation window.

### DIFF
--- a/SlidePilot.xcodeproj/project.pbxproj
+++ b/SlidePilot.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 		5036BD892435F8CD0007AF6F /* AppStartTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartTracker.swift; sourceTree = "<group>"; };
 		5038345924349E8F00E73E43 /* PDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFKit.framework; path = System/Library/Frameworks/PDFKit.framework; sourceTree = SDKROOT; };
 		5038345B24349F4B00E73E43 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
-		5039AE2F25F14C1800C6F232 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = "../../../../../Desktop/Sparkle-1.26.0/Sparkle.framework"; sourceTree = "<group>"; };
+		5039AE2F25F14C1800C6F232 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = SlidePilot/Sparkle.framework; sourceTree = "<group>"; };
 		5039AE3625F14C5C00C6F232 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sparkle.framework; sourceTree = "<group>"; };
 		503FFDF9242A098900B6F438 /* NSDatePicker+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDatePicker+Extension.swift"; sourceTree = "<group>"; };
 		503FFDFB242A180000B6F438 /* PresenterWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenterWindowController.swift; sourceTree = "<group>"; };

--- a/SlidePilot/Base.lproj/Main.storyboard
+++ b/SlidePilot/Base.lproj/Main.storyboard
@@ -622,7 +622,7 @@
             <objects>
                 <windowController storyboardIdentifier="PresentationWindow" id="VPj-fN-aKM" customClass="PresentationWindowController" customModule="SlidePilot" customModuleProvider="target" sceneMemberID="viewController">
                     <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="zZP-Ud-eGP" customClass="PresentationWindow" customModule="SlidePilot" customModuleProvider="target">
-                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="425" y="461" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>

--- a/SlidePilot/PresentationWindowController.swift
+++ b/SlidePilot/PresentationWindowController.swift
@@ -24,9 +24,13 @@ class PresentationWindowController: NSWindowController, NSWindowDelegate {
     override func mouseExited(with event: NSEvent) {
         if trackingTag == event.trackingNumber {
             // hide titlebar (i.e. superview of closebutton)
-            self.window?.standardWindowButton(.closeButton)?.superview?.animator().alphaValue = 0
-            if #available(OSX 11.0, *) {
-                self.window?.titlebarSeparatorStyle = .none
+            if let window = self.window {
+                if !window.styleMask.contains(.fullScreen) {
+                    window.standardWindowButton(.closeButton)?.superview?.animator().alphaValue = 0
+                }
+                if #available(OSX 11.0, *) {
+                    window.titlebarSeparatorStyle = .none
+                }
             }
         }
     }

--- a/SlidePilot/PresentationWindowController.swift
+++ b/SlidePilot/PresentationWindowController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class PresentationWindowController: NSWindowController {
+class PresentationWindowController: NSWindowController, NSWindowDelegate {
     internal var trackingTag: NSView.TrackingRectTag?
 
     override func mouseEntered(with event: NSEvent) {
@@ -40,4 +40,10 @@ class PresentationWindowController: NSWindowController {
         trackingTag = view?.addTrackingRect(view!.bounds, owner: self, userData: nil, assumeInside: false)
     }
     
+    func windowDidResize(_ notification: Notification) {
+        if let view = self.window?.contentView {
+            if let trackingTag = trackingTag { view.removeTrackingRect(trackingTag) }
+            trackingTag = view.addTrackingRect(view.bounds, owner: self, userData: nil, assumeInside: false)
+        }
+    }
 }

--- a/SlidePilot/PresentationWindowController.swift
+++ b/SlidePilot/PresentationWindowController.swift
@@ -13,23 +13,17 @@ class PresentationWindowController: NSWindowController, NSWindowDelegate {
 
     override func mouseEntered(with event: NSEvent) {
         if trackingTag == event.trackingNumber {
-            // show titlebar (i.e. superview of closebutton)
-            self.window?.standardWindowButton(.closeButton)?.superview?.animator().alphaValue = 1
-            if #available(OSX 11.0, *) {
-                self.window?.titlebarSeparatorStyle = .shadow
-            }
+            // show titlebar container (i.e. superview of superview of closebutton)
+            self.window?.standardWindowButton(.closeButton)?.superview?.superview?.animator().alphaValue = 1
         }
     }
     
     override func mouseExited(with event: NSEvent) {
         if trackingTag == event.trackingNumber {
-            // hide titlebar (i.e. superview of closebutton)
+            // hide titlebar container (i.e. superview of superview of closebutton)
             if let window = self.window {
                 if !window.styleMask.contains(.fullScreen) {
-                    window.standardWindowButton(.closeButton)?.superview?.animator().alphaValue = 0
-                }
-                if #available(OSX 11.0, *) {
-                    window.titlebarSeparatorStyle = .none
+                    window.standardWindowButton(.closeButton)?.superview?.superview?.animator().alphaValue = 0
                 }
             }
         }

--- a/SlidePilot/PresentationWindowController.swift
+++ b/SlidePilot/PresentationWindowController.swift
@@ -9,11 +9,35 @@
 import Cocoa
 
 class PresentationWindowController: NSWindowController {
+    internal var trackingTag: NSView.TrackingRectTag?
 
+    override func mouseEntered(with event: NSEvent) {
+        if trackingTag == event.trackingNumber {
+            // show titlebar (i.e. superview of closebutton)
+            self.window?.standardWindowButton(.closeButton)?.superview?.animator().alphaValue = 1
+            if #available(OSX 11.0, *) {
+                self.window?.titlebarSeparatorStyle = .shadow
+            }
+        }
+    }
+    
+    override func mouseExited(with event: NSEvent) {
+        if trackingTag == event.trackingNumber {
+            // hide titlebar (i.e. superview of closebutton)
+            self.window?.standardWindowButton(.closeButton)?.superview?.animator().alphaValue = 0
+            if #available(OSX 11.0, *) {
+                self.window?.titlebarSeparatorStyle = .none
+            }
+        }
+    }
+    
     override func windowDidLoad() {
         super.windowDidLoad()
 
         self.window?.title = NSLocalizedString("Presentation", comment: "Window name for the presentation view.")
+        
+        let view = self.window?.contentView
+        trackingTag = view?.addTrackingRect(view!.bounds, owner: self, userData: nil, assumeInside: false)
     }
     
 }


### PR DESCRIPTION
Hiding the title bar is beneficial when this software is used via screen sharing as described in #68. The proposed code shows the title bar only when the mouse is over the active presentation window (pretty much like quicktime player).

![demo-loop](https://user-images.githubusercontent.com/982241/150613016-6445eac5-f887-4f29-98be-35000f549e09.gif)

